### PR TITLE
src/ydpdict.c: Fix call to undeclared function textdomain

### DIFF
--- a/src/ydpdict.c
+++ b/src/ydpdict.c
@@ -55,6 +55,7 @@
 
 #ifdef HAVE_LOCALE_H
 #include <locale.h>
+#include <libintl.h>
 #endif
 
 #ifdef HAVE_LIBAO


### PR DESCRIPTION
First discovered on Gentoo linux (musl llvm profile).

Bug: https://bugs.gentoo.org/894364